### PR TITLE
Fix: Set code and signature attributes on trace spans

### DIFF
--- a/src/lilypad/lib/traces.py
+++ b/src/lilypad/lib/traces.py
@@ -598,7 +598,6 @@ def trace(
                                 is_versioned=True,
                             )
                         function_uuid = function.uuid
-                        function = function
                     else:
                         function_uuid = None
                         function = None


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/363

Description:
This PR fixes the issue where source code fails to render in the SpanMoreDetails panel.

Cause: The Python SDK wasn't setting the `lilypad.trace.code` and `lilypad.trace.signature` attributes on trace spans.

Changes:

Modified _set_span_attributes in lilypad/lib/traces.py to accept the FunctionPublic object.
If the function object is available, its code and signature are now set as span attributes (lilypad.trace.code, lilypad.trace.signature).
Updated calls to _set_span_attributes within the trace decorator to pass the function object.
This ensures the backend can populate the code field in the SpanMoreDetails API response, allowing the frontend to render it correctly.