### PR TITLE
fix: Add dependency error detection in sandbox runners

### DIFF
--- a/src/lilypad/lib/sandbox/docker.py
+++ b/src/lilypad/lib/sandbox/docker.py
@@ -78,9 +78,11 @@ class DockerSandboxRunner(SandboxRunner):
                 cmd=["uv", "run", "/main.py"],
                 demux=True,
             )
-            if exit_code:
-                raise RuntimeError(f"Error running code in Docker container: {stderr.decode('utf-8').strip()}")
-            return cast(Result, json.loads(stdout.decode("utf-8").strip()))
+
+            stdout_str = stdout.decode("utf-8") if stdout else ""
+            stderr_str = stderr.decode("utf-8") if stderr else ""
+
+            return self.parse_execution_result(stdout_str, stderr_str, exit_code)
         finally:
             if container:
                 with suppress(Exception):

--- a/src/lilypad/lib/sandbox/subprocess.py
+++ b/src/lilypad/lib/sandbox/subprocess.py
@@ -1,7 +1,6 @@
 """Subprocess sandbox runner."""
 
 import os
-import json
 import tempfile
 import subprocess
 from typing import Any, cast
@@ -47,14 +46,11 @@ class SubprocessSandboxRunner(SandboxRunner):
         try:
             result = subprocess.run(
                 ["uv", "run", "--no-project", str(tmp_path)],
-                check=True,
                 capture_output=True,
                 text=True,
                 env=self.environment,
             )
-            return cast(Result, json.loads(result.stdout.strip()))
-        except subprocess.CalledProcessError as e:
-            error_message = f"Process exited with non-zero status.\nStdout: {e.stdout}\nStderr: {e.stderr}"
-            raise RuntimeError(error_message)
+
+            return self.parse_execution_result(result.stdout, result.stderr, result.returncode)
         finally:
             tmp_path.unlink()


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/366

@willbakst @brenkao 
This PR addresses issue https://github.com/Mirascope/lilypad/issues/366 by implementing dependency error detection in sandbox runners.

Instead of automatic invalidation of function versions with dependency errors, I propose we guide users to manage this via CLI/UI. This approach prevents unexpected invalidation of functions that might work in other environments but fail in specific ones.

In this PR:
- Added robust error detection for ImportError and ModuleNotFoundError
- Structured error response with detailed dependency information

Next steps:
- Add CLI command: `lilypad functions invalidate --hash <function_hash>`
- Implement guidance messaging in error responses

Thoughts on this manual invalidation approach vs automatic?