### PR TITLE
fix: Child spans from @lilypad.trace no longer dropped

### DIFF
--- a/src/lilypad/lib/_configure.py
+++ b/src/lilypad/lib/_configure.py
@@ -1,6 +1,5 @@
 """Initialize Lilypad OpenTelemetry instrumentation."""
 
-import os
 import logging
 import importlib.util
 from secrets import token_bytes
@@ -17,8 +16,8 @@ from opentelemetry.sdk.trace.export import (
 )
 
 from ._utils.client import get_sync_client
-from ..types.projects import TraceCreateResponse
 from ._utils.settings import get_settings
+from ._utils.otel_debug import wrap_batch_processor
 from ..types.projects.functions import SpanPublic
 
 try:
@@ -178,6 +177,8 @@ def configure(
     otlp_exporter = _JSONSpanExporter()
     provider = TracerProvider(id_generator=CryptoIdGenerator())
     processor = BatchSpanProcessor(otlp_exporter)  # pyright: ignore[reportArgumentType]
+    if log_level == logging.DEBUG:
+        wrap_batch_processor(processor)
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
 

--- a/src/lilypad/lib/_configure.py
+++ b/src/lilypad/lib/_configure.py
@@ -28,7 +28,8 @@ except ImportError:
 
 DEFAULT_LOG_LEVEL: int = logging.INFO
 
-TraceCreateResponseAdapter = TypeAdapter(TraceCreateResponse)
+# Ignore pydantic deprecation warnings by using `list[SpanPublic]` instead of `TraceCreateResponse`
+TraceCreateResponseAdapter = TypeAdapter(list[SpanPublic])
 
 
 class CryptoIdGenerator(IdGenerator):

--- a/src/lilypad/lib/_utils/middleware.py
+++ b/src/lilypad/lib/_utils/middleware.py
@@ -96,7 +96,7 @@ def _get_custom_context_manager(
                 "lilypad.is_async": is_async,
             }
             if decorator_tags is not None:
-                attributes["lilypad.decorator.tags"] = json_dumps(decorator_tags)
+                attributes["lilypad.trace.tags"] = decorator_tags
             if function:
                 attribute_type = "function"
                 attributes["lilypad.function.uuid"] = str(function.uuid)

--- a/src/lilypad/lib/_utils/middleware.py
+++ b/src/lilypad/lib/_utils/middleware.py
@@ -96,6 +96,8 @@ def _get_custom_context_manager(
                 "lilypad.is_async": is_async,
                 "lilypad.decorator.tags": decorator_tags,
             }
+            if decorator_tags is not None:
+                attributes["lilypad.decorator.tags"] = json_dumps(decorator_tags)
             if function:
                 attribute_type = "function"
                 attributes["lilypad.function.uuid"] = str(function.uuid)

--- a/src/lilypad/lib/_utils/middleware.py
+++ b/src/lilypad/lib/_utils/middleware.py
@@ -94,7 +94,6 @@ def _get_custom_context_manager(
             attributes: dict[str, AttributeValue] = {
                 "lilypad.project_uuid": str(new_project_uuid) if new_project_uuid else "",
                 "lilypad.is_async": is_async,
-                "lilypad.decorator.tags": decorator_tags,
             }
             if decorator_tags is not None:
                 attributes["lilypad.decorator.tags"] = json_dumps(decorator_tags)

--- a/src/lilypad/lib/_utils/otel_debug.py
+++ b/src/lilypad/lib/_utils/otel_debug.py
@@ -1,0 +1,32 @@
+import logging
+
+from opentelemetry.sdk.trace.export import ReadableSpan, BatchSpanProcessor
+
+log = logging.getLogger("lilypad.otel-debug")
+log.setLevel(logging.DEBUG)
+if not log.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s  %(levelname)s  %(message)s", "%H:%M:%S"))
+    log.addHandler(handler)
+
+
+def wrap_batch_processor(processor: BatchSpanProcessor) -> None:
+    """Monkey-patch BatchSpanProcessor to log enqueue / flush activity."""
+
+    origin_on_end = processor.on_end
+    origin_flush = processor.force_flush
+
+    def on_end(span: ReadableSpan) -> None:
+        qsize = len(processor.queue)
+        log.debug("[on_end ] enqueue span=%s  queue=%d→%d", span.name, qsize, qsize + 1)
+        origin_on_end(span)
+
+    def force_flush(timeout_millis: int = 5_000):  # noqa: D401
+        qsize_before = len(processor.queue)
+        log.debug("[flush   ] called  queue=%d", qsize_before)
+        result = origin_flush(timeout_millis)
+        log.debug("[flush   ] done    queue=%d  result=%s", len(processor.queue), result)
+        return result
+
+    processor.on_end = on_end  # type: ignore
+    processor.force_flush = force_flush  # type: ignore

--- a/src/lilypad/lib/spans.py
+++ b/src/lilypad/lib/spans.py
@@ -1,13 +1,46 @@
 """A context manager for creating a tracing span with parent-child relationship tracking,"""
 
+import time
 import datetime
 from typing import Any
-from contextlib import AbstractContextManager
+from functools import lru_cache  # noqa: TID251
+from contextlib import AbstractContextManager, suppress
+from contextvars import ContextVar
 
 from opentelemetry import context as context_api
-from opentelemetry.trace import Span as OTSpan, StatusCode, get_tracer, set_span_in_context
+from opentelemetry.trace import Span as OTSpan, StatusCode, get_tracer, get_tracer_provider, set_span_in_context
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from lilypad.lib._utils.json import json_dumps
+
+_trace_level: ContextVar[int] = ContextVar("_trace_level", default=0)
+
+
+@lru_cache(maxsize=1)
+def get_batch_span_processor() -> BatchSpanProcessor | None:
+    """Get the BatchSpanProcessor from the current TracerProvider.
+
+    Retrieve the BatchSpanProcessor from the current TracerProvider dynamically.
+    This avoids using a global variable by inspecting the provider's _active_span_processors.
+    """
+    tracer_provider = get_tracer_provider()
+    if hasattr(tracer_provider, "get_active_span_processor"):
+        active_processor = tracer_provider.get_active_span_processor()
+        if hasattr(active_processor, "_span_processors"):
+            for processor in active_processor._span_processors:
+                if isinstance(processor, BatchSpanProcessor):
+                    return processor
+        elif isinstance(active_processor, BatchSpanProcessor):
+            return active_processor
+    elif hasattr(tracer_provider, "_active_span_processor"):
+        processor = getattr(tracer_provider, "_active_span_processor", None)
+        if isinstance(processor, BatchSpanProcessor):
+            return processor
+        elif hasattr(processor, "_span_processors"):
+            for span_processors in processor._span_processors:
+                if isinstance(span_processors, BatchSpanProcessor):
+                    return span_processors
+    return None
 
 
 class Span:
@@ -45,6 +78,14 @@ class Span:
 
         if self._span is not None:
             self._span.end()
+
+        if self._span and self._span.parent is None:
+            proc = get_batch_span_processor()
+            if proc:
+                for _ in range(3):  # max 3 tries
+                    if proc.force_flush(timeout_millis=5_000):
+                        break
+                    time.sleep(0.05)
 
         if self._token:
             context_api.detach(self._token)

--- a/src/lilypad/lib/traces.py
+++ b/src/lilypad/lib/traces.py
@@ -555,7 +555,8 @@ def _set_span_attributes(
     span_attribute["lilypad.project_uuid"] = settings.project_id if settings.project_id else ""
     span_attribute["lilypad.type"] = trace_type
     span_attribute["lilypad.is_async"] = is_async
-    span_attribute["lilypad.trace.tags"] = decorator_tags
+    if decorator_tags is not None:
+        span_attribute["lilypad.trace.tags"] = decorator_tags
     if function:
         function_uuid = function.uuid
         span_attribute[f"lilypad.{trace_type}.signature"] = function.signature

--- a/tests/lib/test_spans.py
+++ b/tests/lib/test_spans.py
@@ -38,6 +38,7 @@ class DummySpan:
         self.attributes: dict[str, Any] = {}
         self.events: list[tuple[str, dict[str, Any]]] = []
         self.ended: bool = False
+        self.parent: "DummySpan" | None = None
         dummy_spans.append(self)
 
     def set_attribute(self, key: str, value: Any) -> None:


### PR DESCRIPTION
Moved the locking logic from the `@trace` decorator to the Span class itself, ensuring that parent and child spans are always exported together.

Fixes: https://github.com/Mirascope/lilypad/issues/440