### PR TITLE
Fix: AttributeError when handling modules without __qualname__ attribute

### DIFF
--- a/src/lilypad/lib/_utils/closure.py
+++ b/src/lilypad/lib/_utils/closure.py
@@ -585,6 +585,9 @@ class _DependencyCollector:
             elif hasattr(definition, "func") and getattr(definition, "__name__", None) is None:
                 definition = definition.func  # pyright: ignore [reportFunctionMemberAccess]
 
+            if isinstance(definition, ModuleType):
+                return
+
             # For methods, if __qualname__ contains a dot, does not include "<locals>" (global)
             # or if it is local (contains "<locals>"), capture the entire class.
             if "." in definition.__qualname__ and inspect.getmodule(definition) is not None:

--- a/tests/lib/_utils/closure/closure_test_functions/main.py
+++ b/tests/lib/_utils/closure/closure_test_functions/main.py
@@ -1,6 +1,8 @@
 """The main methods for testing the `Closure class."""
 
 import os
+import time
+import random
 import inspect
 import importlib.metadata
 from typing import Any, Literal, TypeAlias
@@ -835,3 +837,25 @@ class Chatbot:
                 return f"Hello, {self.name}!"
         """
         return f"Hello, {self.name}!"
+
+
+def fn_using_time_module():
+    """
+    import time
+
+
+    def fn_using_time_module():
+        return time.time()
+    """
+    return time.time()
+
+
+def fn_using_random_module():
+    """
+    import random
+
+
+    def fn_using_random_module():
+        return random.random()
+    """
+    return random.random()

--- a/tests/lib/_utils/closure/test_closure.py
+++ b/tests/lib/_utils/closure/test_closure.py
@@ -56,6 +56,8 @@ from .closure_test_functions.main import (
     handle_issue,
     raw_string_fn,
     multiple_literal_fn,
+    fn_using_time_module,
+    fn_using_random_module,
     multi_joined_string_fn,
     empty_body_fn_docstrings,
     nested_base_model_definitions,
@@ -634,3 +636,21 @@ def test_get_qualified_name_handles_locals():
     simple_name = get_qualified_name(inner_fn)
     # Expected simple name is "inner"
     assert simple_name == "inner"
+
+
+def test_module_without_qualname_time():
+    """Test the `Closure` class with a module that doesn't have __qualname__ attribute (time)."""
+
+    closure = Closure.from_fn(fn_using_time_module)
+    assert closure.code == _expected(fn_using_time_module)
+    assert "time" in closure.code
+    assert closure.dependencies == {}
+
+
+def test_module_without_qualname_random():
+    """Test the `Closure` class with a module that doesn't have __qualname__ attribute (random)."""
+
+    closure = Closure.from_fn(fn_using_random_module)
+    assert closure.code == _expected(fn_using_random_module)
+    assert "random" in closure.code
+    assert closure.dependencies == {}


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/499